### PR TITLE
complex-step derivatives

### DIFF
--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -438,6 +438,15 @@ def _sparse_difference(fun, x0, f0, h, use_one_sided,
 
             rows = i[~mask]
             df[rows] = f2[rows] - f1[rows]
+        elif method == 'cs':
+            f1 = fun(x0 + h_vec*1.j)
+            df = f1.imag
+            dx = h_vec
+            cols, = np.where(e)
+            i, j, v = find(structure[:, cols])
+            j = cols[j]
+        else:
+            raise ValueError("Never be here.")
 
         J[i, j] = df[i] / dx[j]
 

--- a/scipy/optimize/tests/test__numdiff.py
+++ b/scipy/optimize/tests/test__numdiff.py
@@ -425,7 +425,7 @@ class TestApproxDerivativeSparse(object):
         groups_2 = group_columns(A, order)
 
         for method, groups, l, u in product(
-                ['2-point', '3-point'], [groups_1, groups_2],
+                ['2-point', '3-point', 'cs'], [groups_1, groups_2],
                 [-np.inf, self.lb], [np.inf, self.ub]):
             J = approx_derivative(self.fun, self.x0, method=method,
                                   bounds=(l, u), sparsity=(A, groups))
@@ -441,7 +441,7 @@ class TestApproxDerivativeSparse(object):
     def test_equivalence(self):
         structure = np.ones((self.n, self.n), dtype=int)
         groups = np.arange(self.n)
-        for method in ['2-point', '3-point']:
+        for method in ['2-point', '3-point', 'cs']:
             J_dense = approx_derivative(self.fun, self.x0, method=method)
             J_sparse = approx_derivative(
                 self.fun, self.x0, sparsity=(structure, groups), method=method)

--- a/scipy/optimize/tests/test__numdiff.py
+++ b/scipy/optimize/tests/test__numdiff.py
@@ -186,36 +186,48 @@ class TestApproxDerivativesDense(object):
         jac_diff_2 = approx_derivative(self.fun_scalar_scalar, x0,
                                        method='2-point')
         jac_diff_3 = approx_derivative(self.fun_scalar_scalar, x0)
+        jac_diff_4 = approx_derivative(self.fun_scalar_scalar, x0,
+                                       method='cs')
         jac_true = self.jac_scalar_scalar(x0)
         assert_allclose(jac_diff_2, jac_true, rtol=1e-6)
         assert_allclose(jac_diff_3, jac_true, rtol=1e-9)
+        assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
 
     def test_scalar_vector(self):
         x0 = 0.5
         jac_diff_2 = approx_derivative(self.fun_scalar_vector, x0,
                                        method='2-point')
         jac_diff_3 = approx_derivative(self.fun_scalar_vector, x0)
+        jac_diff_4 = approx_derivative(self.fun_scalar_vector, x0,
+                                       method='cs')
         jac_true = self.jac_scalar_vector(np.atleast_1d(x0))
         assert_allclose(jac_diff_2, jac_true, rtol=1e-6)
         assert_allclose(jac_diff_3, jac_true, rtol=1e-9)
+        assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
 
     def test_vector_scalar(self):
         x0 = np.array([100.0, -0.5])
         jac_diff_2 = approx_derivative(self.fun_vector_scalar, x0,
                                        method='2-point')
         jac_diff_3 = approx_derivative(self.fun_vector_scalar, x0)
+        jac_diff_4 = approx_derivative(self.fun_vector_scalar, x0,
+                                       method='cs')
         jac_true = self.jac_vector_scalar(x0)
         assert_allclose(jac_diff_2, jac_true, rtol=1e-6)
         assert_allclose(jac_diff_3, jac_true, rtol=1e-7)
+        assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
 
     def test_vector_vector(self):
         x0 = np.array([-100.0, 0.2])
         jac_diff_2 = approx_derivative(self.fun_vector_vector, x0,
                                        method='2-point')
         jac_diff_3 = approx_derivative(self.fun_vector_vector, x0)
+        jac_diff_4 = approx_derivative(self.fun_vector_vector, x0,
+                                       method='cs')
         jac_true = self.jac_vector_vector(x0)
         assert_allclose(jac_diff_2, jac_true, rtol=1e-5)
         assert_allclose(jac_diff_3, jac_true, rtol=1e-6)
+        assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
 
     def test_wrong_dimensions(self):
         x0 = 1.0
@@ -340,6 +352,10 @@ class TestApproxDerivativesDense(object):
         jac_diff_3 = approx_derivative(self.jac_non_numpy, x0)
         assert_allclose(jac_diff_2, jac_true, rtol=1e-6)
         assert_allclose(jac_diff_3, jac_true, rtol=1e-8)
+
+        # math.exp cannot handle complex arguments, hence this raises
+        assert_raises(TypeError, approx_derivative, self.jac_non_numpy, x0,
+                                       **dict(method='cs'))
 
     def test_check_derivative(self):
         x0 = np.array([-10.0, 10])


### PR DESCRIPTION
numdiff only, will add to least_squares once the validation etc settles.

We discussed the limitations of this. One motivation for adding this is eg, item 1 in http://ceres-solver.org/faqs.html
Explicit use of automatic derivatives belongs to the userland for scipy. For numerical differentiation, cs scheme is probably the most accurate. 
